### PR TITLE
Update python-tools.R

### DIFF
--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -8,7 +8,7 @@ python_has_module <- function(python, module) {
 python_version <- function(python) {
   code <- "import platform; print(platform.python_version())"
   args <- c("-E", "-c", shQuote(code))
-  output <- system2(python, args, stdout = TRUE)
+  output <- system2(python, args, stdout = TRUE, stderr = TRUE)
   numeric_version(output)
 }
 
@@ -16,7 +16,7 @@ python_module_version <- function(python, module) {
   fmt <- "import %1$s; print(%1$s.__version__)"
   code <- sprintf(fmt, module)
   args <- c("-E", "-c", shQuote(code))
-  output <- system2(python, args, stdout = TRUE)
+  output <- system2(python, args, stdout = TRUE, stderr = TRUE)
   numeric_version(output)
 }
 


### PR DESCRIPTION
R3.6 with Windows seems to have some problem to deliver the stdout from python scripts, so this is a try to add the stderr=T to the system2 function